### PR TITLE
Only run CI on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 
 os:
   - linux
-  - osx
 
 addons:
   apt:


### PR DESCRIPTION
The OSX builds are busted at the moment, and were previously taking too long to even finish. We should re-enable them once they work, but for the meantime it would be very great to keep Linux green and have CI pass/fail based on that.

r? @tschneidereit 